### PR TITLE
🎨 コンテナのパディングを統一

### DIFF
--- a/pages/art/3d/index.vue
+++ b/pages/art/3d/index.vue
@@ -8,7 +8,7 @@
         3D Art
       </template>
     </PageHeader>
-    <div class="container md:mx-auto px-2 mb-16 mt-8">
+    <div class="container mx-auto mb-16 mt-8">
       Coming Soon...
     </div>
   </div>

--- a/pages/art/css/index.vue
+++ b/pages/art/css/index.vue
@@ -10,7 +10,7 @@ import PerformanceMonitor from '~/components/Art/PerformanceMonitor.vue'
         CSS Art
       </template>
     </PageHeader>
-    <div class="container md:mx-auto px-2 mb-16 mt-8">
+    <div class="container mx-auto mb-16 mt-8">
       <PerformanceMonitor
         :enabled="true"
         position="bottom-right" />

--- a/pages/art/graphics.vue
+++ b/pages/art/graphics.vue
@@ -207,7 +207,7 @@ function selectShader(shader) {
       </template>
     </PageHeader>
 
-    <div class="container md:mx-auto px-2 mb-16 mt-8">
+    <div class="container mx-auto mb-16 mt-8">
       <div class="space-y-8">
         <!-- Introduction -->
         <Card>

--- a/pages/art/index.vue
+++ b/pages/art/index.vue
@@ -32,7 +32,7 @@ const artCategories = [
       </template>
     </PageHeader>
 
-    <div class="container md:mx-auto px-2 mb-16 mt-8">
+    <div class="container mx-auto mb-16 mt-8">
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         <NuxtLink
           v-for="category in artCategories"

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -53,7 +53,7 @@ const links = computed(() => {
 
 <template>
   <ThreeColumnLayout
-    class="container md:mx-auto px-2 mb-16"
+    class="container mx-auto mb-16"
     :left="{ class: 'hidden' }"
     :main="{ class: 'md:col-span-9 xl:col-span-9 col-span-12' }"
     :right="{ class: 'md:col-span-3 xl:col-span-3 col-span-0' }">

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -15,7 +15,7 @@ const { data } = await useAsyncData(() => queryCollection('blog')
         Blog
       </template>
     </PageHeader>
-    <div class="container md:mx-auto px-2 mb-16 mt-8">
+    <div class="container mx-auto mb-16 mt-8">
       <ul class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         <li
           v-for="(post, index) in data"

--- a/pages/career/index.vue
+++ b/pages/career/index.vue
@@ -43,7 +43,7 @@ const careersWithProjects = computed(() => {
         Career
       </template>
     </PageHeader>
-    <div class="container md:mx-auto px-2 mb-16 mt-8">
+    <div class="container mx-auto mb-16 mt-8">
       <ul class="grid grid-cols-1 gap-8">
         <li
           v-for="(career, index) in careersWithProjects"

--- a/pages/project/index.vue
+++ b/pages/project/index.vue
@@ -16,7 +16,7 @@ const { data: pinnedProjects } = await useAsyncData(() => queryCollection('proje
         My Project
       </template>
     </PageHeader>
-    <div class="container md:mx-auto px-2 mb-16 mt-8">
+    <div class="container mx-auto mb-16 mt-8">
       <h1 class="text-4xl font-monomaniac-one my-8 text-center">
       </h1>
       <ul class="grid grid-cols-1 gap-4 xl:grid-cols-2">


### PR DESCRIPTION
## Summary
- 各ページのコンテナクラスで使用されている `md:mx-auto px-2` を `mx-auto` に統一
- レスポンシブデザインの一貫性を向上

## Test plan
- [ ] 各ページのレイアウトが正しく表示されることを確認
- [ ] モバイル・タブレット・デスクトップの各画面サイズで表示を確認
- [ ] コンテナの余白が適切に設定されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)