### PR TITLE
✨ ProjectCardでIconifyアイコンと画像URLの両方をサポート

### DIFF
--- a/components/project/ProjectCard.vue
+++ b/components/project/ProjectCard.vue
@@ -35,6 +35,14 @@ const date_span = computed(() => {
   }
   return props.data.period_start + ' ~ ' + props.data.period_end
 })
+
+const isImageUrl = computed(() => {
+  const icon = props.data.icon
+  return icon.startsWith('http://')
+    || icon.startsWith('https://')
+    || icon.startsWith('/')
+    || /\.(png|jpg|jpeg|svg|webp)$/i.test(icon)
+})
 </script>
 
 <template>
@@ -68,7 +76,13 @@ const date_span = computed(() => {
           <div class="col-span-full flex items-start gap-4">
             <div
               class="flex items-center justify-center shrink-0 rounded-full border border-transparent shadow-md backdrop-blur-md size-20 group-hover:shadow-primary/20 transition-all duration-300">
+              <img
+                v-if="isImageUrl"
+                :src="data.icon"
+                :alt="data.title"
+                class="size-12 object-contain">
               <Icon
+                v-else
                 :name="data.icon"
                 class="text-white text-5xl" />
             </div>

--- a/content/4.project/X1.2025-01.SilentCast.md
+++ b/content/4.project/X1.2025-01.SilentCast.md
@@ -1,0 +1,36 @@
+---
+title: SilentCast
+description: ホットキー駆動型タスクランナー
+rank: 0
+icon: https://spherestacking.github.io/SilentCast/logo.svg
+stacks:
+  - go
+  - gohook
+  - systray
+  - yaml
+  - vitepress
+overview:
+  - ホットキーでタスクを実行するクロスプラットフォーム対応アプリケーション
+  - VS Codeスタイルの連続キー入力対応（例：g,s でgit status）
+  - Windows/macOS/Linux対応
+tasks:
+  - ホットキー機能の実装
+  - 設定ファイル（spellbook.yml）の管理
+  - クロスプラットフォーム対応
+  - システムトレイ統合
+  - ドキュメント整備
+team: 1人
+role: オーナー
+period_start: 2024-01
+period_end: ""
+status: in_progress
+tags:
+  - 個人開発
+  - デスクトップアプリ
+  - 自動化ツール
+links:
+  - label: GitHub
+    url: https://github.com/SphereStacking/SilentCast
+  - label: docs
+    url: https://spherestacking.github.io/SilentCast/
+---


### PR DESCRIPTION
## Summary
- ProjectCardコンポーネントのiconプロパティで、Iconifyアイコンと画像URLの両方を使用できるように拡張
- プロジェクトごとに柔軟なアイコン設定が可能に

## 実装内容
- `isImageUrl` computedプロパティを追加して、iconプロパティの値を判定
- 判定基準:
  - `http://` または `https://` で始まる（外部URL）
  - `/` で始まる（ローカル画像）
  - 画像拡張子（.png, .jpg, .jpeg, .svg, .webp）を含む
- テンプレートでv-ifを使用して条件分岐:
  - 画像URLの場合: `<img>` タグを使用
  - Iconifyアイコンの場合: `<Icon>` コンポーネントを使用

## 対応形式の例
- Iconifyアイコン: `icon: fluent-emoji:blue-circle`
- 外部画像URL: `icon: https://example.com/logo.svg`
- ローカル画像: `icon: /favicon.svg`

## テスト
- SilentCastプロジェクトに外部画像URLを設定して動作確認済み

## Test plan
- [x] 既存のIconifyアイコンが正常に表示されることを確認
- [x] 外部画像URLが正常に表示されることを確認
- [ ] ローカル画像パスが正常に表示されることを確認
- [ ] 画像のサイズとスタイルが適切に適用されることを確認